### PR TITLE
BACKLOG-3497 -- Add a group that already exists displays a warning wi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-engine-test</artifactId>
       <version>${dependency.kettle.revision}</version>

--- a/src/main/resources/org/pentaho/di/trans/steps/annotation/messages/messages_en_US.properties
+++ b/src/main/resources/org/pentaho/di/trans/steps/annotation/messages/messages_en_US.properties
@@ -54,7 +54,7 @@ ModelAnnotation.MissingSharedDimension.Message={0} could not be found. You may n
 ModelAnnotation.AnnotationGroupExists.Title=Annotation Group Exists
 ModelAnnotation.AnnotationGroupExists.Message={0} already exists. Do you want to replace the existing Annotation Group with this one?
 ModelAnnotation.AnnotationGroupExists.Yes=Yes, Replace
-ModelAnnotation.UnableToRename.Title=Unable to Rename
+ModelAnnotation.UnableToRename.Title=Name Already Exists 
 ModelAnnotation.UnableToRename.Message=There''s already an Annotation Group named {0}. Do you want to select that group? You will lose your unsaved changes.
 
 #####################################################################


### PR DESCRIPTION
…ndow

with title "Unable to Rename"Add a group that already exists displays a
warning window with title "Unable to Rename"

What was done:
1) Changed dialog title