### PR TITLE
[BACKLOG-8241] - Adding metadata injection to AnnotateStream step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <dependency.pentaho-metadata.revision>7.0-SNAPSHOT</dependency.pentaho-metadata.revision>
     <dependency.osgi.version>4.3.1</dependency.osgi.version>
     <dependency.jaxrs.revision>1.1.1</dependency.jaxrs.revision>
-    <maven-bundle-plugin.version>2.3.7</maven-bundle-plugin.version>
+    <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
     <dependency.junit.revision>4.7</dependency.junit.revision>
     <dependency.pentaho-modeler.revision>7.0-SNAPSHOT</dependency.pentaho-modeler.revision>
     <dependency.mockito.revision>1.8.4</dependency.mockito.revision>
@@ -43,6 +43,7 @@
     <dependency.bi-platform.revision>7.0-SNAPSHOT</dependency.bi-platform.revision>
     <dependency.h2.revision>1.0.78</dependency.h2.revision>
     <dependency.xstream.revision>1.2.2</dependency.xstream.revision>
+    <dependency.commons.collections.revision>3.2.2</dependency.commons.collections.revision>
   </properties>
   <dependencies>
     <dependency>
@@ -107,6 +108,17 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${dependency.commons.io.revision}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>${dependency.commons.collections.revision}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey.contribs</groupId>

--- a/src/main/java/org/pentaho/di/trans/steps/annotation/ModelAnnotationMeta.java
+++ b/src/main/java/org/pentaho/di/trans/steps/annotation/ModelAnnotationMeta.java
@@ -25,6 +25,10 @@ package org.pentaho.di.trans.steps.annotation;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
+import org.pentaho.agilebi.modeler.models.annotations.CreateAttribute;
+import org.pentaho.agilebi.modeler.models.annotations.CreateCalculatedMember;
+import org.pentaho.agilebi.modeler.models.annotations.CreateMeasure;
+import org.pentaho.agilebi.modeler.models.annotations.LinkDimension;
 import org.pentaho.agilebi.modeler.models.annotations.ModelAnnotation;
 import org.pentaho.agilebi.modeler.models.annotations.ModelAnnotationGroup;
 import org.pentaho.agilebi.modeler.models.annotations.ModelAnnotationGroupXmlReader;
@@ -37,6 +41,9 @@ import org.pentaho.di.core.annotations.Step;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.injection.Injection;
+import org.pentaho.di.core.injection.InjectionDeep;
+import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.ObjectId;
@@ -63,6 +70,8 @@ import java.util.UUID;
 /**
  * @author Rowell Belen
  */
+@InjectionSupported( localizationPrefix = "AnnotateStream.Injection.",
+    groups = {"MEASURE", "ATTRIBUTE", "LINK_DIMENSION", "CALC_MEASURE"} )
 @Step( id = "FieldMetadataAnnotation", image = "ModelAnnotation.svg",
     i18nPackageName = "org.pentaho.di.trans.steps.annotation", name = "ModelAnnotation.TransName",
     description = "ModelAnnotation.TransDescription",
@@ -72,13 +81,33 @@ public class ModelAnnotationMeta extends BaseStepMeta implements StepMetaInterfa
 
   private static Class<?> PKG = ModelAnnotationMeta.class; // for i18n purposes, needed by Translator2!!
 
+  @Injection( name = "IS_SHARED" )
   private boolean sharedDimension; // need to know this before loading from the MetaStore
 
   private ModelAnnotationGroup modelAnnotations;
 
+  @Injection( name = "SHARED_ANNOTATION_GROUP" )
   private String modelAnnotationCategory;
 
   private String targetOutputStep;
+
+  /////////////////////////////////////////////////////
+  // Temp fields required to support metadata injection
+  // These will be injected via the annotation-based injection system.
+  // It's up to the init() method of the ModelAnnotationStep to take them and fill in the "real" fields they correspond to
+  @InjectionDeep
+  protected transient List<CreateMeasure> createMeasureAnnotations = new ArrayList<>();
+
+  @InjectionDeep
+  protected transient List<CreateAttribute> createAttributeAnnotations = new ArrayList<>();
+
+  @InjectionDeep
+  protected transient List<LinkDimension> createLinkDimensionAnnotations = new ArrayList<>();
+
+  @InjectionDeep
+  protected transient List<CreateCalculatedMember> createCalcMeasureAnnotations = new ArrayList<>();
+  // end temp fields
+  /////////////////////////////////////////////////////
 
   public ModelAnnotationGroup getModelAnnotations() {
     return modelAnnotations;

--- a/src/main/java/org/pentaho/di/trans/steps/annotation/ModelAnnotationMeta.java
+++ b/src/main/java/org/pentaho/di/trans/steps/annotation/ModelAnnotationMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Community Edition Project: data-refinery-pdi-plugin
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  * *******************************************************************************
  *

--- a/src/main/java/org/pentaho/di/trans/steps/annotation/ModelAnnotationStep.java
+++ b/src/main/java/org/pentaho/di/trans/steps/annotation/ModelAnnotationStep.java
@@ -22,11 +22,14 @@
 
 package org.pentaho.di.trans.steps.annotation;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.pentaho.agilebi.modeler.models.annotations.AnnotationType;
 import org.pentaho.agilebi.modeler.models.annotations.CreateMeasure;
 import org.pentaho.agilebi.modeler.models.annotations.ModelAnnotation;
 import org.pentaho.agilebi.modeler.models.annotations.ModelAnnotationGroup;
 import org.pentaho.agilebi.modeler.models.annotations.ModelAnnotationManager;
+import org.pentaho.agilebi.modeler.models.annotations.ModelProperty;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.ValueMetaInterface;
@@ -42,6 +45,9 @@ import org.pentaho.di.trans.step.StepMetaDataCombi;
 import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.metadata.model.concept.types.AggregationType;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Rowell Belen
@@ -197,4 +203,66 @@ public class ModelAnnotationStep extends BaseStep implements StepInterface {
     }
     return false;
   }
+
+  @Override public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
+    ModelAnnotationMeta meta = (ModelAnnotationMeta) smi;
+
+    ModelAnnotationGroup modelAnnotations = meta.getModelAnnotations();
+
+    // if a shared dimension is referenced, assume we should not be injecting any annotations. they will come from there
+    if ( !meta.isSharedDimension() ) {
+      if ( modelAnnotations == null ) {
+        modelAnnotations = new ModelAnnotationGroup();
+        meta.setModelAnnotations( modelAnnotations );
+      }
+
+      addInjectedAnnotations( modelAnnotations, meta.createMeasureAnnotations );
+      addInjectedAnnotations( modelAnnotations, meta.createAttributeAnnotations );
+      addInjectedAnnotations( modelAnnotations, meta.createLinkDimensionAnnotations );
+      addInjectedAnnotations( modelAnnotations, meta.createCalcMeasureAnnotations );
+    }
+
+    final boolean superInit = super.init( smi, sdi );
+    return superInit;
+  }
+
+  protected void addInjectedAnnotations( ModelAnnotationGroup modelAnnotations,
+                                       List<? extends AnnotationType> annotations ) {
+
+    for ( AnnotationType annotationType : annotations ) {
+      ModelAnnotation existingAnnotation = findExistingAnnotation( modelAnnotations, annotationType );
+      ModelAnnotation ma = existingAnnotation == null ? new ModelAnnotation() : existingAnnotation;
+
+      ma.setName( annotationType.getName() );
+
+      if ( existingAnnotation == null ) {
+        ma.setAnnotation( annotationType );
+
+        modelAnnotations.add( ma );
+      } else {
+        // set each of the specific values that are injected onto the existing annotation
+        List<ModelProperty> modelProperties = annotationType.getModelProperties();
+        modelProperties.stream().forEach( modelProperty -> {
+          try {
+            Object value = annotationType.getModelPropertyValueById( modelProperty.id() );
+            if ( value != null ) {
+              ma.getAnnotation().setModelPropertyValueById( modelProperty.id(), value );
+            }
+          } catch ( Exception e ) {
+            // this shouldn't happen since we are iterating over the properties
+          }
+        } );
+
+      }
+    }
+  }
+
+  protected ModelAnnotation findExistingAnnotation( ModelAnnotationGroup modelAnnotations, AnnotationType annotation ) {
+    List<ModelAnnotation> matches = modelAnnotations.stream()
+      .filter( ma -> ma.getAnnotation().equalsLogically( annotation ) )
+      .collect( Collectors.toList() );
+
+    return CollectionUtils.isNotEmpty( matches ) ? matches.get( 0 ) : null;
+  }
+
 }

--- a/src/main/resources/org/pentaho/di/trans/steps/annotation/messages/messages_en_US.properties
+++ b/src/main/resources/org/pentaho/di/trans/steps/annotation/messages/messages_en_US.properties
@@ -149,3 +149,47 @@ CalculatedMeasure.Composite.Format.Label=Format:
 CalculatedMeasure.Composite.Formula.Label=Formula:
 CalculatedMeasure.Composite.Subtotal.Label=When calculating subtotals use this formula
 CalculatedMeasure.Composite.Hidden.Label=Hide this calculated measure in the model
+
+#####################################################################
+##
+##  Metadata Injection descriptions
+##
+#####################################################################
+AnnotateStream.Injection.IS_SHARED=Specify a new or choose an existing shared annotation group?
+AnnotateStream.Injection.SHARED_ANNOTATION_GROUP=The name of the shared annotation group.
+
+AnnotateStream.Injection.MEASURE=Create Measure
+AnnotateStream.Injection.MEASURE_NAME=The name of the measure.
+AnnotateStream.Injection.MEASURE_AGGREGATION_TYPE=Specify a format string or choose from a list of aggregation types.
+AnnotateStream.Injection.MEASURE_FIELD=The name of the field to be annotated.
+AnnotateStream.Injection.MEASURE_FORMAT_STRING=Specifiy how this field should be formatted.
+AnnotateStream.Injection.MEASURE_DESCRIPTION=This is a brief description for the annotation.
+AnnotateStream.Injection.MEASURE_IS_HIDDEN=This option will hide this measure in the data model.
+
+AnnotateStream.Injection.ATTRIBUTE=Create Attribute
+AnnotateStream.Injection.ATTRIBUTE_NAME=The name of the attribute.
+AnnotateStream.Injection.ATTRIBUTE_FIELD=The name of the field to be annotated.
+AnnotateStream.Injection.ATTRIBUTE_ORDINAL_FIELD=This option will allow you to sort members in ascending order.
+AnnotateStream.Injection.ATTRIBUTE_FORMAT_STRING=Specify how this field should be formatted.
+AnnotateStream.Injection.ATTRIBUTE_DESCRIPTION=This is a brief description for the annotation.
+AnnotateStream.Injection.ATTRIBUTE_IS_HIDDEN=This option will hide this attribute in the data model.
+AnnotateStream.Injection.ATTRIBUTE_IS_UNIQUE=Specify whether a data member(s) is unique across all parents.
+AnnotateStream.Injection.ATTRIBUTE_TIME_FORMAT=This option lets you specify a time format. This is a required field for Time Level attributes.
+AnnotateStream.Injection.ATTRIBUTE_TIME_TYPE=This option lets you specify a time type. This is a required field for Time Level attributes.
+AnnotateStream.Injection.ATTRIBUTE_GEO_TYPE=This option lets you specify a geo type. This is a required field for Geo Type attributes.
+AnnotateStream.Injection.ATTRIBUTE_PARENT=This option allows you to create multi-level hierarchies.
+AnnotateStream.Injection.ATTRIBUTE_DIMENSION=This option lets you specify an existing dimension or create a new dimension for the attribute. This is a required field.
+AnnotateStream.Injection.ATTRIBUTE_HIERARCHY=This option lets you specify an existing hierarchy or create a new hierarchy for the attribute.
+
+AnnotateStream.Injection.LINK_DIMENSION=Link Dimension
+AnnotateStream.Injection.LINK_DIMENSION_DIMENSION_NAME=The name of the dimension.
+AnnotateStream.Injection.LINK_DIMENSION_SHARED_DIMENSION_NAME=Specify a new or choose an existing shared dimension?
+AnnotateStream.Injection.LINK_DIMENSION_FIELD=The name of the field to be annotated.
+
+AnnotateStream.Injection.CALC_MEASURE=Calculated Measure
+AnnotateStream.Injection.CALC_MEASURE_NAME=The name of the calculated measure.
+AnnotateStream.Injection.CALC_MEASURE_FORMAT_STRING=Specify how you want your calculated measure to appear in a report.
+AnnotateStream.Injection.CALC_MEASURE_DESCRIPTION=This is a brief description of the annotation.
+AnnotateStream.Injection.CALC_MEASURE_IS_HIDDEN=This option will hide this calculated measure in the data model.
+AnnotateStream.Injection.CALC_MEASURE_CALCULATE_SUBTOTALS=This option will allow your calculated measure to be used in calculations of subtotals in your reports.
+AnnotateStream.Injection.CALC_MEASURE_FORMULA=The formula of your calculated measure.


### PR DESCRIPTION
[BACKLOG-8241] - Adding support for metadata injection of the annotate stream step

This depends on https://github.com/pentaho/modeler/pull/283
