### PR TITLE
[BACKLOG-9661] - allowing Shared Dimension to succeed when provider i…

### DIFF
--- a/src/main/java/org/pentaho/di/trans/steps/annotation/ModelAnnotationStep.java
+++ b/src/main/java/org/pentaho/di/trans/steps/annotation/ModelAnnotationStep.java
@@ -78,9 +78,10 @@ public class ModelAnnotationStep extends BaseStep implements StepInterface {
       ModelAnnotationData modelAnnotationData = (ModelAnnotationData) sdi;
       if ( modelAnnotationMeta.isSharedDimension()
           && !isOutputStepFound( modelAnnotationMeta.getTargetOutputStep() ) ) {
-        throw new KettleException( BaseMessages.getString( PKG, "ModelAnnotation.Runtime.MissingDataProvider" ) );
+        log.logError( BaseMessages.getString( PKG, "ModelAnnotation.Runtime.MissingDataProvider" )  );
+      } else {
+        modelAnnotationData.annotations = processAnnotations( modelAnnotationMeta );
       }
-      modelAnnotationData.annotations = processAnnotations( modelAnnotationMeta );
     }
     if ( row == null ) { // no more input to be expected...
       setOutputDone();

--- a/src/main/java/org/pentaho/di/trans/steps/annotation/SharedDimensionStep.java
+++ b/src/main/java/org/pentaho/di/trans/steps/annotation/SharedDimensionStep.java
@@ -47,7 +47,6 @@ public class SharedDimensionStep extends ModelAnnotationStep implements StepInte
     meta.setSharedDimension( true );
     if ( StringUtils.isNotEmpty( meta.sharedDimensionName ) ) {
       meta.setModelAnnotationCategory( meta.sharedDimensionName );
-      meta.getModelAnnotations().setName( meta.sharedDimensionName );
     }
     if ( StringUtils.isNotEmpty( meta.dataProviderStep ) ) {
       meta.setTargetOutputStep( meta.dataProviderStep );
@@ -59,6 +58,7 @@ public class SharedDimensionStep extends ModelAnnotationStep implements StepInte
       meta.setModelAnnotations( modelAnnotations );
     }
 
+    meta.getModelAnnotations().setName( meta.getModelAnnotationCategory() );
     modelAnnotations.addInjectedAnnotations( meta.createDimensionKeyAnnotations );
     modelAnnotations.addInjectedAnnotations( meta.createAttributeAnnotations );
 

--- a/src/test/java/org/pentaho/di/trans/steps/annotation/SharedDimensionStepTest.java
+++ b/src/test/java/org/pentaho/di/trans/steps/annotation/SharedDimensionStepTest.java
@@ -41,8 +41,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class SharedDimensionStepTest {
 
@@ -89,6 +88,8 @@ public class SharedDimensionStepTest {
     attrAnnotations.add( new CreateAttribute() );
     meta.createAttributeAnnotations = attrAnnotations;
 
+    meta.sharedDimensionName = "myName";
+
     ModelAnnotationGroup modelAnnotationGroup = new ModelAnnotationGroup();
     meta.setModelAnnotations( modelAnnotationGroup );
 
@@ -96,6 +97,7 @@ public class SharedDimensionStepTest {
     assertEquals( 2, modelAnnotationGroup.size() );
     assertEquals( ModelAnnotation.Type.CREATE_DIMENSION_KEY, modelAnnotationGroup.get( 0 ).getType() );
     assertEquals( ModelAnnotation.Type.CREATE_ATTRIBUTE, modelAnnotationGroup.get( 1 ).getType() );
+    assertEquals( "myName", modelAnnotationGroup.getName() );
     assertTrue( status );
   }
 }


### PR DESCRIPTION
…s not found.  Ensuring the model annotation group has a name before saving in the metastore