### PR TITLE
[BACKLOG-8388] - Upgrade Jersey to 1.19.1 across the suite for Java 8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </scm>
   <properties>
     <dependency.pdi-dataservice-plugin.revision>7.0-SNAPSHOT</dependency.pdi-dataservice-plugin.revision>
-    <dependency.jersey-apache-client.revision>1.14</dependency.jersey-apache-client.revision>
+    <dependency.jersey-apache-client.revision>1.19.1</dependency.jersey-apache-client.revision>
     <dependency.apache-xmlgraphics.revision>1.7</dependency.apache-xmlgraphics.revision>
     <dependency.pentaho-metadata.revision>7.0-SNAPSHOT</dependency.pentaho-metadata.revision>
     <dependency.osgi.version>4.3.1</dependency.osgi.version>
@@ -35,7 +35,7 @@
     <dependency.pentaho-osgi-bundles.revision>7.0-SNAPSHOT</dependency.pentaho-osgi-bundles.revision>
     <dependency.commons.io.revision>1.4</dependency.commons.io.revision>
     <dependency.commons.lang.revision>2.6</dependency.commons.lang.revision>
-    <dependency.jersey.revision>1.16</dependency.jersey.revision>
+    <dependency.jersey.revision>1.19.1</dependency.jersey.revision>
     <dependency.jackson.revision>1.9.2</dependency.jackson.revision>
     <dependency.data-access-plugin.revision>7.0-SNAPSHOT</dependency.data-access-plugin.revision>
     <dependency.pentaho-xul.revision>7.0-SNAPSHOT</dependency.pentaho-xul.revision>
@@ -238,7 +238,7 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
-            <Import-Package>!com.sun.jersey.api.json;version="[1.16,2)",
+            <Import-Package>!com.sun.jersey.api.json;version="[1.19.1,2)",
               !org.codehaus.jackson.jaxrs,
               org.pentaho.di.osgi,
               org.pentaho.di.core.plugins,


### PR DESCRIPTION
The fix is needed due to using java 1.8, and incompatibility of asm old version (is used by jersey) reading new java 1.8 features 
The following scope of repositories is upgraded(except webdetails): The list is sorted in the order of build team runs

https://github.com/pentaho/pentaho-reporting
https://github.com/pentaho/mondrian
https://github.com/pentaho/pentaho-kettle
https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins
https://github.com/pentaho/pentaho-platform
https://github.com/webdetails/cpf
https://github.com/pentaho/pentaho-metaverse
https://github.com/pentaho/pdi-platform-utils-plugin
https://github.com/pentaho/pentaho-data-profiling
https://github.com/pentaho/data-access
https://github.com/pentaho/big-data-plugin
https://github.com/pentaho/pentaho-data-refinery
https://github.com/webdetails/cde
https://github.com/webdetails/cpk
https://github.com/webdetails/cda
https://github.com/pentaho/pentaho-platform-plugin-mobile
https://github.com/pentaho/pentaho-karaf-assembly
https://github.com/pentaho/pentaho-karaf-ee-assembly
https://github.com/pentaho/pdi-sdk-plugins
https://github.com/pentaho/pdi-ee-plugin
https://github.com/pentaho/pdi-agile-bi-plugin
https://github.com/pentaho/pentaho-aggdesigner
https://github.com/pentaho/pentaho-metadata-editor