### PR TITLE
[SP-2817] - Backport of PDI-15316 - Mouseover tooltip on auto-publish…

### DIFF
--- a/src/main/resources/org/pentaho/di/job/entries/publish/messages/messages_en_US.properties
+++ b/src/main/resources/org/pentaho/di/job/entries/publish/messages/messages_en_US.properties
@@ -25,7 +25,7 @@ AclDefinition.AccessType.Role=Role
 
 ServerConnection.Group.Label=BA Server Connection
 ServerConnection.Url.Label=URL:
-ServerConnection.Url.Tooltip=The path to your BA Server. (Example: http://localhost:8080)
+ServerConnection.Url.Tooltip=The path to your BA Server. (Example: http://localhost:8080/pentaho)
 ServerConnection.User.Label=User Name:
 ServerConnection.User.Tooltip=User must have permission to publish.
 ServerConnection.Password.Label=Password:


### PR DESCRIPTION
… job entry contains misleading example (6.1 Suite)

@pamval, here is backport of https://github.com/pentaho/pentaho-data-refinery/commit/c4a4da6ed7f59b217dca3daaa948c34789d14c89 to 6.1. Thanks.
