### PR TITLE
BACKLOG-10902 -Stack trace in report when using a "Database tables" data

### DIFF
--- a/src/main/java/org/pentaho/di/job/entries/publish/JobEntryDatasourcePublish.java
+++ b/src/main/java/org/pentaho/di/job/entries/publish/JobEntryDatasourcePublish.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Community Edition Project: data-refinery-pdi-plugin
  *
- * Copyright (C) 2002-20156by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  * *******************************************************************************
  *
@@ -161,7 +161,6 @@ public class JobEntryDatasourcePublish extends JobEntryBase implements Cloneable
       // Publish Database Meta
       databaseMeta = discoverDatabaseMeta( getParentJob().getJobMeta() );
       if ( databaseMeta != null ) {
-
         // Cannot publish JNDI data sources at this time, we don't know if BIServer has access to it
         if ( DatabaseAccessType.values()[databaseMeta.getAccessType()] == DatabaseAccessType.JNDI ) {
           throw new KettleException(
@@ -352,6 +351,11 @@ public class JobEntryDatasourcePublish extends JobEntryBase implements Cloneable
     if ( isKettleThinLocal( databaseMeta ) ) {
       throw new KettleException( getMsg( "JobEntryDatasourcePublish.Publish.LocalPentahoDataService" ) );
     }
+
+    if ( isKettleThin( databaseMeta ) ) {
+      databaseMeta.setForcingIdentifiersToLowerCase( false );
+    }
+
     modelServerPublish.setDatabaseMeta( databaseMeta ); // provide database info
 
     // TODO Simple Check - Need to make this smarter and inspect the database connection
@@ -434,8 +438,12 @@ public class JobEntryDatasourcePublish extends JobEntryBase implements Cloneable
   }
 
   private boolean isKettleThinLocal( final DatabaseMeta databaseMeta ) {
-    return DataServiceConnectionInformation.KETTLE_THIN.equals( databaseMeta.getDatabaseInterface().getPluginId() )
+    return isKettleThin( databaseMeta )
       && "true".equals( databaseMeta.getExtraOptions().get( DataServiceConnectionInformation.KETTLE_THIN + ".local" ) );
+  }
+
+  private boolean isKettleThin( final DatabaseMeta databaseMeta ) {
+    return DataServiceConnectionInformation.KETTLE_THIN.equals( databaseMeta.getDatabaseInterface().getPluginId() );
   }
 
   protected void publishMondrianSchema( final String modelName, final ModelServerPublish modelServerPublish,

--- a/src/test/java/org/pentaho/di/job/entries/publish/JobEntryDatasourcePublishTest.java
+++ b/src/test/java/org/pentaho/di/job/entries/publish/JobEntryDatasourcePublishTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.database.model.DatabaseAccessType;
 import org.pentaho.database.model.DatabaseConnection;
+import org.pentaho.di.core.database.BaseDatabaseMeta;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.ProvidesDatabaseConnectionInformation;
 import org.pentaho.di.core.Result;
@@ -61,6 +62,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
@@ -261,11 +263,16 @@ public class JobEntryDatasourcePublishTest {
     when( modelServerPublish.connectionNameExists( anyString() ) ).thenReturn( databaseConnection );
     when( modelServerPublish.publishDataSource( anyBoolean(), anyString() ) ).thenReturn( true );
     final DatabaseInterface databaseInterface = mock( DatabaseInterface.class );
+    Properties props = new Properties();
+    when( databaseInterface.getAttributes() ).thenReturn( props );
     when( databaseMeta.getDatabaseInterface() ).thenReturn( databaseInterface );
     when( databaseInterface.getPluginId() ).thenReturn( "KettleThin" );
     when( databaseMeta.getExtraOptions() ).thenReturn( new HashMap<String, String>() );
     try {
+      assertTrue( databaseMeta.getDatabaseInterface().getAttributes()
+          .getProperty( BaseDatabaseMeta.ATTRIBUTE_FORCE_IDENTIFIERS_TO_LOWERCASE ) == null );
       datasourcePublishSpy.publishDatabaseMeta( modelServerPublish, databaseMeta, false );
+      assertFalse( databaseMeta.isForcingIdentifiersToLowerCase() );
     } catch ( KettleException e ) {
       fail( "did not expect exception " + e.getMessage() );
     }


### PR DESCRIPTION
source of a published Dataservice connection

What was done:
1) changed the property for publishing kettle data sources
2) updated test