### PR TITLE
[BACKLOG-10097] As a new user to Pentaho and creating a connection to…

### DIFF
--- a/src/test/java/org/pentaho/di/core/refinery/publish/agilebi/ModelServerPublishTest.java
+++ b/src/test/java/org/pentaho/di/core/refinery/publish/agilebi/ModelServerPublishTest.java
@@ -159,7 +159,6 @@ public class ModelServerPublishTest {
     final String dbName = "dbName";
     final String dbPort = "dbPort";
     final String hostname = "hostname";
-    final String webAppName = "pentaho-di";
 
     doReturn( extraOptions ).when( databaseMeta ).getExtraOptions();
     doReturn( username ).when( databaseMeta ).getUsername();

--- a/src/test/java/org/pentaho/di/job/entries/build/DataServiceConnectionInformationTest.java
+++ b/src/test/java/org/pentaho/di/job/entries/build/DataServiceConnectionInformationTest.java
@@ -117,7 +117,7 @@ public class DataServiceConnectionInformationTest {
         + "  <id>PentahoEnterpriseRepository</id>\n"
         + "  <name>local</name>\n"
         + "  <description>a</description>\n"
-        + "  <repository_location_url>http&#x3a;&#x2f;&#x2f;farfaraway&#x3a;12345&#x2f;pentaho-di</repository_location_url>\n"
+        + "  <repository_location_url>http&#x3a;&#x2f;&#x2f;farfaraway&#x3a;12345&#x2f;pentaho</repository_location_url>\n"
         + "  <version_comment_mandatory>N</version_comment_mandatory>\n"
         + "</repository>"
     );
@@ -131,7 +131,7 @@ public class DataServiceConnectionInformationTest {
     assertEquals( "Kettle", connectInfo.getSchemaName() );
     DatabaseMeta databaseMeta = connectInfo.getDatabaseMeta();
     assertEquals( "org.pentaho.di.trans.dataservice.jdbc.ThinDriver", databaseMeta.getDriverClass() );
-    assertEquals( "pentaho-di", databaseMeta.getDatabaseName() );
+    assertEquals( "pentaho", databaseMeta.getDatabaseName() );
     assertEquals( dataServiceName, databaseMeta.getName() );
     assertNull( databaseMeta.getExtraOptions().get( "KettleThin.local" ) );
     assertEquals( "farfaraway", databaseMeta.getHostname() );
@@ -148,7 +148,7 @@ public class DataServiceConnectionInformationTest {
       + "  <id>KettleFileRepository</id>\n"
       + "  <name>local</name>\n"
       + "  <description>a</description>\n"
-      + "  <repository_location_url>http&#x3a;&#x2f;&#x2f;farfaraway&#x3a;12345&#x2f;pentaho-di</repository_location_url>\n"
+      + "  <repository_location_url>http&#x3a;&#x2f;&#x2f;farfaraway&#x3a;12345&#x2f;pentaho</repository_location_url>\n"
       + "  <version_comment_mandatory>N</version_comment_mandatory>\n"
       + "</repository>" );
     DataServiceConnectionInformation connectInfo = new DataServiceConnectionInformation( dataServiceName, repository,
@@ -164,7 +164,7 @@ public class DataServiceConnectionInformationTest {
       + "  <id>PentahoEnterpriseRepository</id>\n"
       + "  <name>local</name>\n"
       + "  <description>a</description>\n"
-      + "  <repository_location>http&#x3a;&#x2f;&#x2f;farfaraway&#x3a;12345&#x2f;pentaho-di</repository_location>\n"
+      + "  <repository_location>http&#x3a;&#x2f;&#x2f;farfaraway&#x3a;12345&#x2f;pentaho</repository_location>\n"
       + "  <version_comment_mandatory>N</version_comment_mandatory>\n"
       + "</repository>" );
     DataServiceConnectionInformation connectInfo =


### PR DESCRIPTION
… Pentaho Data Services, I want the default web-app name for the Data Service driver to use 'pentaho' instead of 'pentaho-di' since there is no such web-app in 7.0
@hudak @mkambol 
See also https://github.com/pentaho/pentaho-commons-database/pull/108