### PR TITLE
[BACKLOG-11857] - only save shared dimensions back to metastore on in…

### DIFF
--- a/src/main/java/org/pentaho/di/trans/steps/annotation/SharedDimensionStep.java
+++ b/src/main/java/org/pentaho/di/trans/steps/annotation/SharedDimensionStep.java
@@ -61,7 +61,9 @@ public class SharedDimensionStep extends ModelAnnotationStep implements StepInte
     modelAnnotations.addInjectedAnnotations( meta.createAttributeAnnotations );
 
     try {
-      meta.saveToMetaStore( getMetaStore() );
+      if ( !meta.createAttributeAnnotations.isEmpty() || !meta.createDimensionKeyAnnotations.isEmpty() ) {
+        meta.saveToMetaStore( getMetaStore() );
+      }
     } catch ( Exception e ) {
       logError( e.getMessage(), e );
     }

--- a/src/test/java/org/pentaho/di/trans/steps/annotation/SharedDimensionStepTest.java
+++ b/src/test/java/org/pentaho/di/trans/steps/annotation/SharedDimensionStepTest.java
@@ -100,4 +100,22 @@ public class SharedDimensionStepTest {
     assertEquals( "myName", modelAnnotationGroup.getName() );
     assertTrue( status );
   }
+
+  @Test
+  public void testNoInjectionDoesNotSaveToMetastore() throws Exception {
+    // step
+    StepDataInterface stepDataInterface = new ModelAnnotationData();
+    SharedDimensionStep modelAnnotationStep = createSharedDimensionStep( stepDataInterface, null );
+
+    SharedDimensionMeta meta = new SharedDimensionMeta() {
+      @Override public void saveToMetaStore( IMetaStore metaStore )
+        throws Exception {
+        fail( "should not try and save to metastore because not meta injected" );
+      }
+    };
+
+    meta.sharedDimensionName = "myName";
+    boolean status = modelAnnotationStep.init( meta, stepDataInterface );
+    assertTrue( status );
+  }
 }


### PR DESCRIPTION
…it if the annotations were meta-injected into the step