### PR TITLE
PDI-15515- Removing legacy ESAPI encoder from projects

### DIFF
--- a/src/main/resources/ESAPI.properties
+++ b/src/main/resources/ESAPI.properties
@@ -1,1 +1,0 @@
-ESAPI.Encoder=org.owasp.esapi.reference.DefaultEncoder


### PR DESCRIPTION
Removing legacy ESAPI encoder from projects and replacing it by org.owasp.encoder.