### PR TITLE
[PPP-3581] CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to P…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <properties>
     <dependency.pdi-dataservice-plugin.revision>7.1-SNAPSHOT</dependency.pdi-dataservice-plugin.revision>
     <dependency.jersey-apache-client.revision>1.19.1</dependency.jersey-apache-client.revision>
-    <dependency.apache-xmlgraphics.revision>1.7</dependency.apache-xmlgraphics.revision>
+    <dependency.apache-xmlgraphics.revision>1.8</dependency.apache-xmlgraphics.revision>
     <dependency.pentaho-metadata.revision>7.1-SNAPSHOT</dependency.pentaho-metadata.revision>
     <dependency.commons.collections.revision>3.2.2</dependency.commons.collections.revision>
     <dependency.osgi.version>4.3.1</dependency.osgi.version>


### PR DESCRIPTION
[PPP-3581] CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to PNG and SVG to JPG conversion classes