### PR TITLE
[SP-3097] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnera…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </scm>
   <properties>
     <dependency.commons.io.revision>1.4</dependency.commons.io.revision>
-    <dependency.apache-xmlgraphics.revision>1.7</dependency.apache-xmlgraphics.revision>
+    <dependency.apache-xmlgraphics.revision>1.7.1</dependency.apache-xmlgraphics.revision>
     <dependency.kettle.revision>6.1-SNAPSHOT</dependency.kettle.revision>
     <dependency.bi-platform.revision>6.1-SNAPSHOT</dependency.bi-platform.revision>
     <dependency.data-access-plugin.revision>6.1-SNAPSHOT</dependency.data-access-plugin.revision>


### PR DESCRIPTION
[SP-3097] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to PNG and SVG to JPG conversion classes (6.1 Suite)