### PR TITLE
[TEST] - New method setJobMeta in JobEntryInterface was breaking tests.

### DIFF
--- a/src/test/java/org/pentaho/di/job/entries/build/JobEntryBuildModelTest.java
+++ b/src/test/java/org/pentaho/di/job/entries/build/JobEntryBuildModelTest.java
@@ -183,6 +183,7 @@ public class JobEntryBuildModelTest {
         return connectionValidator;
       }
 
+      @Override public void setParentJobMeta ( JobMeta jb ) { }
       @Override public ProvidesDatabaseConnectionInformation getConnectionInfo() {
         return connectionInfo;
       }


### PR DESCRIPTION
Apparently, mockito is not picking up the default implementation defined here: 

https://github.com/pentaho/pentaho-kettle/commit/3b4fdcec86f7d0818c4f815e8d1c023ddb0fc07a#diff-93c6c6dddfabbecdfa1350bb7e9e5429R735

