### PR TITLE
[ANALYZER-3559]-When filtering the date field (format YYYY-MM-DD HH:MM:SS.0) it shows "The report has no data"

### DIFF
--- a/src/main/java/org/pentaho/di/core/refinery/model/DswModeler.java
+++ b/src/main/java/org/pentaho/di/core/refinery/model/DswModeler.java
@@ -426,12 +426,25 @@ public class DswModeler {
     }
 
     public boolean equals( ColumnKey other ) {
-      return this.dataType.equals( other.dataType )
-          && this.columnName.equals( other.columnName );
+      return this.columnName.equals( other.columnName ) && ( this.dataType.equals( other.dataType ) || (
+        DataType.TIMESTAMP.equals( this.dataType ) && DataType.DATE.equals( other.dataType )
+          || DataType.DATE.equals( this.dataType ) && DataType.TIMESTAMP.equals( other.dataType ) ) );
     }
 
     public int hashCode() {
-      return columnName.hashCode() + 31 * dataType.hashCode();
+      int hash;
+      switch ( dataType ) {
+        case TIMESTAMP:
+        case DATE: {
+          hash = DataType.DATE.hashCode();
+          break;
+        }
+        default: {
+          hash = dataType.hashCode();
+          break;
+        }
+      }
+      return columnName.hashCode() + 31 * hash;
     }
 
     public String getColumnName() {


### PR DESCRIPTION
As was introduced new datatype Timestamp which is known by mondrian. And previously we generate timesamp dates like datatype date. Was done workaround to support backward compatibility on update scheme. 
It occurs only when previously we had incorrect mapping timestamp db column to our date type.