### PR TITLE
[PPP-3892] Use of vulnerable component org.codehaus.jackson : jackson-mapper-asl : 1.5.2, org.codehaus.jackson : jackson-mapper-asl : 1.9.12, org.codehaus.jackson : jackson-mapper-asl 1.9.13,org.codehaus.jackson:jackson-mapper-asl-1.8.8.jar CVE-2017-7525

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <pentaho-osgi-bundles.version>8.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <dependency.commons.io.revision>1.4</dependency.commons.io.revision>
     <dependency.jersey.revision>1.19.1</dependency.jersey.revision>
-    <dependency.jackson.revision>1.9.2</dependency.jackson.revision>
+    <dependency.jackson.revision>2.9.4</dependency.jackson.revision>
     <pentaho-data-access.version>8.1.0.0-SNAPSHOT</pentaho-data-access.version>
     <commons-xul.version>8.1.0.0-SNAPSHOT</commons-xul.version>
     <pdi.version>8.1.0.0-SNAPSHOT</pdi.version>
@@ -71,6 +71,12 @@
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-engine</artifactId>
       <version>${pdi.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-bundle</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>
@@ -117,6 +123,10 @@
           <groupId>com.google.gwt</groupId>
           <artifactId>gwt-dev</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-bundle</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -158,11 +168,6 @@
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-bundle</artifactId>
-      <version>${dependency.jersey.revision}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-core</artifactId>
       <version>${dependency.jersey.revision}</version>
     </dependency>
@@ -170,6 +175,12 @@
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-json</artifactId>
       <version>${dependency.jersey.revision}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>
@@ -180,6 +191,16 @@
       <groupId>javax.ws.rs</groupId>
       <artifactId>jsr311-api</artifactId>
       <version>${dependency.jaxrs.revision}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <version>${dependency.jackson.revision}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${dependency.jackson.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -212,12 +233,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>${dependency.jackson.revision}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.0.1</version>
@@ -235,6 +250,12 @@
       <version>${pdi.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-bundle</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>xerces</groupId>

--- a/src/main/java/org/pentaho/di/core/refinery/publish/util/JAXBUtils.java
+++ b/src/main/java/org/pentaho/di/core/refinery/publish/util/JAXBUtils.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Community Edition Project: data-refinery-pdi-plugin
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  * *******************************************************************************
  *
@@ -22,12 +22,11 @@
 
 package org.pentaho.di.core.refinery.publish.util;
 
-import com.sun.jersey.api.json.JSONJAXBContext;
-import com.sun.jersey.api.json.JSONMarshaller;
-import com.sun.jersey.api.json.JSONUnmarshaller;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
@@ -38,6 +37,14 @@ import java.io.StringWriter;
  * @author Rowell Belen
  */
 public class JAXBUtils {
+
+  private static ObjectMapper mapper = new ObjectMapper();
+  private static JaxbAnnotationModule module = new JaxbAnnotationModule();
+
+  static {
+    mapper.configure( MapperFeature.USE_STD_BEAN_NAMING, true );
+    mapper.registerModule( module );
+  }
 
   public static String marshallToXml( Object source ) throws Exception {
     JAXBContext jaxbContext = JAXBContext.newInstance( source.getClass() );
@@ -57,22 +64,11 @@ public class JAXBUtils {
   }
 
   public static String marshallToJson( Object source ) throws Exception {
-    JAXBContext jaxbContext = JAXBContext.newInstance( source.getClass() );
-    Marshaller marshaller = jaxbContext.createMarshaller();
-    marshaller.setProperty( Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE );
-    JSONMarshaller jsonMarshaller = JSONJAXBContext.getJSONMarshaller( marshaller, jaxbContext );
-    StringWriter writer = new StringWriter();
-    jsonMarshaller.marshallToJSON( source, writer );
-    return writer.toString();
+    return mapper.writeValueAsString( source );
   }
 
   public static <T> T unmarshalFromJson( final String json, Class<T> destinationClass ) throws Exception {
-    JAXBContext jaxbContext = JAXBContext.newInstance( destinationClass );
-    Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-    JSONUnmarshaller jsonUnmarshaller = JSONJAXBContext.getJSONUnmarshaller( unmarshaller, jaxbContext );
-    StringReader reader = new StringReader( json );
-    JAXBElement<T> element = jsonUnmarshaller.unmarshalJAXBElementFromJSON( reader, destinationClass );
-    return element.getValue();
+    return mapper.readValue( json, destinationClass );
   }
 
 }


### PR DESCRIPTION
- classloader issue was fixed
- jackson 1 was removed
- unnecessary jersey-bundle import was removed