### PR TITLE
[BACKLOG-25015] Refactor: StepMetaInferface holds a new default metho…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <platform.version>9.0.0.0-SNAPSHOT</platform.version>
     <dependency.commons.lang.revision>2.6</dependency.commons.lang.revision>
     <dependency.h2.revision>1.0.78</dependency.h2.revision>
+    <pentaho-hadoop-shims-api.version>${project.version}</pentaho-hadoop-shims-api.version>
   </properties>
   <dependencies>
     <dependency>
@@ -80,11 +81,6 @@
     <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-ui-swt</artifactId>
-      <version>${pdi.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho.di.plugins</groupId>
-      <artifactId>meta-inject-plugin</artifactId>
       <version>${pdi.version}</version>
     </dependency>
     <dependency>
@@ -264,6 +260,18 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-api</artifactId>
+      <version>${pentaho-hadoop-shims-api.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/org/pentaho/di/trans/util/TransUtil.java
+++ b/src/main/java/org/pentaho/di/trans/util/TransUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Community Edition Project: data-refinery-pdi-plugin
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  * *******************************************************************************
  *
@@ -31,7 +31,6 @@ import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
-import org.pentaho.di.trans.steps.metainject.MetaInjectMeta;
 import org.pentaho.metastore.api.IMetaStore;
 
 import java.util.HashMap;
@@ -45,13 +44,17 @@ public class TransUtil {
         new HashMap<String, ProvidesDatabaseConnectionInformation>();
     for ( StepMeta stepMeta : transMeta.getSteps() ) {
       ProvidesDatabaseConnectionInformation info = getDatabaseConnectionInformation( stepMeta.getStepMetaInterface() );
+
       if ( info != null ) {
         stepMap.put( StringUtils.trimToEmpty( stepMeta.getName() ), info );
-      } else if ( stepMeta.getStepMetaInterface() instanceof MetaInjectMeta ) {
-        MetaInjectMeta metaInject = ( (MetaInjectMeta) stepMeta.getStepMetaInterface() );
-        TransMeta injectedTransMeta =
-            MetaInjectMeta.loadTransformationMeta( metaInject, repository, metastore, transMeta );
-        stepMap.putAll( collectOutputStepInTrans( injectedTransMeta, repository, metastore ) );
+      } else if ( stepMeta != null && stepMeta.getStepMetaInterface() != null ) {
+
+        TransMeta relatedTransMeta = stepMeta.getStepMetaInterface().fetchTransMeta( stepMeta.getStepMetaInterface(),
+            repository, metastore, transMeta );
+
+        if ( relatedTransMeta != null ) {
+          stepMap.putAll( collectOutputStepInTrans( relatedTransMeta, repository, metastore ) );
+        }
       }
     }
     return stepMap;


### PR DESCRIPTION
…d interface, which will allows for the decoupling of PDI-data-refinery from ETL Metadata injection step

- Refactor: `StepMetaInferface` holds a new default method interface, which will allow for decoupling of PDI-data-refinery from ETL Metadata injection step
- Also makes it so that any `StepMetaInterface`, should they care to implement `fetchTransMeta()`,  could potentially become a drillable Step

Also: fixed some of the failing unit tests ( not all ), that were failing due to 

```
Caused by: java.lang.ClassNotFoundException: org.pentaho.hadoop.shim.ConfigurationException
```

Should be merged alongside https://github.com/pentaho/pentaho-kettle/pull/5687

@pentaho/rogueone @kurtwalker @tmcsantos @mdamour1976 