### PR TITLE
[BACKLOG-42955]-Upgrading jackson-module-jaxb-annotations to jackson-module-jakarta-xmlbind-annotations to support Jakarta EE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -216,7 +216,7 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <version>2.4.0-b180830.0438</version>
+      <version>${jakarta.xml.bind-api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>

--- a/src/main/java/org/pentaho/di/core/refinery/publish/util/JAXBUtils.java
+++ b/src/main/java/org/pentaho/di/core/refinery/publish/util/JAXBUtils.java
@@ -15,7 +15,7 @@ package org.pentaho.di.core.refinery.publish.util;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.Marshaller;
@@ -30,7 +30,7 @@ import java.io.StringWriter;
 public class JAXBUtils {
 
   private static ObjectMapper mapper = new ObjectMapper();
-  private static JaxbAnnotationModule module = new JaxbAnnotationModule();
+  private static JakartaXmlBindAnnotationModule module = new JakartaXmlBindAnnotationModule();
 
   static {
     mapper.configure( MapperFeature.USE_STD_BEAN_NAMING, true );

--- a/src/test/java/org/pentaho/di/core/refinery/publish/util/JAXBUtilTest.java
+++ b/src/test/java/org/pentaho/di/core/refinery/publish/util/JAXBUtilTest.java
@@ -14,7 +14,6 @@
 package org.pentaho.di.core.refinery.publish.util;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.pentaho.database.model.DatabaseConnection;
 
@@ -34,7 +33,6 @@ public class JAXBUtilTest {
     new JAXBUtils();
   }
 
-  @Ignore
   @Test
   public void test() throws Exception {
 


### PR DESCRIPTION
[BACKLOG-42955]-Upgrading jackson-module-jaxb-annotations to jackson-module-jakarta-xmlbind-annotations to support Jakarta EE

[BACKLOG-42955]: https://hv-eng.atlassian.net/browse/BACKLOG-42955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ