### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,10 +37,7 @@
     <pdi.version>11.0.0.0-SNAPSHOT</pdi.version>
     <platform.version>11.0.0.0-SNAPSHOT</platform.version>
 
-    <dependency.jersey.version>2.44</dependency.jersey.version>
     <dependency.javax.ws.rs-api.version>2.1</dependency.javax.ws.rs-api.version>
-    <dependency.osgi-resource-locator.version>1.0.3</dependency.osgi-resource-locator.version>
-    <dependency.mimepull.version>1.9.15</dependency.mimepull.version>
     <dependency.apache-xmlgraphics.revision>1.8</dependency.apache-xmlgraphics.revision>
     <dependency.commons.collections.revision>3.2.2</dependency.commons.collections.revision>
     <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
@@ -177,27 +174,27 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>${dependency.jersey.version}</version>
+      <version>${jersey-osgi.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>${dependency.jersey.version}</version>
+      <version>${jersey-osgi.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>${dependency.jersey.version}</version>
+      <version>${jersey-osgi.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>osgi-resource-locator</artifactId>
-      <version>${dependency.osgi-resource-locator.version}</version>
+      <version>${jersey-osgi-resource-locator}</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.mimepull</groupId>
       <artifactId>mimepull</artifactId>
-      <version>${dependency.mimepull.version}</version>
+      <version>${mimepull-osgi.version}</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
       <version>${pdi.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-bundle</artifactId>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -129,24 +129,8 @@
       <version>${pentaho-modeler.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>com.google.gwt</groupId>
-          <artifactId>gwt-dev</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-bundle</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-client</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey.contribs</groupId>
-          <artifactId>jersey-apache-client</artifactId>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -187,7 +171,7 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
       <version>${fasterxml-jackson.version}</version>
     </dependency>
     <dependency>
@@ -201,8 +185,8 @@
       <version>${dependency.jersey.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-common</artifactId>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
       <version>${dependency.jersey.version}</version>
     </dependency>
     <dependency>
@@ -279,8 +263,8 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-bundle</artifactId>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-server</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
     <dependency>
       <groupId>com.hitachivantara.security.web</groupId>
       <artifactId>csrf-token-service-client-java-jax-rs-v2</artifactId>
+      <version>${hv-security-web.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -187,6 +188,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <version>${fasterxml-jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,8 @@
     <pdi.version>11.0.0.0-SNAPSHOT</pdi.version>
     <platform.version>11.0.0.0-SNAPSHOT</platform.version>
 
-    <dependency.jersey.revision>1.19.1</dependency.jersey.revision>
-    <dependency.jersey-apache-client.revision>1.19.1</dependency.jersey-apache-client.revision>
     <dependency.apache-xmlgraphics.revision>1.8</dependency.apache-xmlgraphics.revision>
     <dependency.commons.collections.revision>3.2.2</dependency.commons.collections.revision>
-    <dependency.jaxrs.revision>1.1.1</dependency.jaxrs.revision>
     <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
     <dependency.junit.revision>4.13.2</dependency.junit.revision>
     <dependency.mockito.revision>5.10.0</dependency.mockito.revision>
@@ -140,7 +137,7 @@
 
     <dependency>
       <groupId>com.hitachivantara.security.web</groupId>
-      <artifactId>csrf-token-service-client-java-jax-rs-v1</artifactId>
+      <artifactId>csrf-token-service-client-java-jax-rs-v2</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -167,47 +164,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-multipart</artifactId>
-      <version>${dependency.jersey.revision}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-apache-client</artifactId>
-      <version>${dependency.jersey-apache-client.revision}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-httpclient</groupId>
-          <artifactId>commons-httpclient</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-core</artifactId>
-      <version>${dependency.jersey.revision}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
-      <version>${dependency.jersey.revision}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-client</artifactId>
-      <version>${dependency.jersey.revision}</version>
-    </dependency>
-
-    <dependency>
       <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-      <version>${dependency.jaxrs.revision}</version>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>${javax.ws.rs-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
@@ -216,6 +175,56 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-multipart</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.4.0-b180830.0438</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-processing</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.ext</groupId>
+      <artifactId>jersey-spring5</artifactId>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,18 @@
           <groupId>com.sun.jersey</groupId>
           <artifactId>jersey-bundle</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey.contribs</groupId>
+          <artifactId>jersey-apache-client</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,10 @@
     <pdi.version>11.0.0.0-SNAPSHOT</pdi.version>
     <platform.version>11.0.0.0-SNAPSHOT</platform.version>
 
+    <dependency.jersey.version>2.44</dependency.jersey.version>
+    <dependency.javax.ws.rs-api.version>2.1</dependency.javax.ws.rs-api.version>
+    <dependency.osgi-resource-locator.version>1.0.3</dependency.osgi-resource-locator.version>
+    <dependency.mimepull.version>1.9.15</dependency.mimepull.version>
     <dependency.apache-xmlgraphics.revision>1.8</dependency.apache-xmlgraphics.revision>
     <dependency.commons.collections.revision>3.2.2</dependency.commons.collections.revision>
     <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
@@ -178,65 +182,36 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs-api.version}</version>
+      <version>${dependency.javax.ws.rs-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-server</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.containers</groupId>
-      <artifactId>jersey-container-servlet</artifactId>
-      <version>${jersey.version}</version>
+      <version>${dependency.jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>${jersey.version}</version>
+      <version>${dependency.jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-common</artifactId>
-      <version>${jersey.version}</version>
+      <version>${dependency.jersey.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.4.0-b180830.0438</version>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>osgi-resource-locator</artifactId>
+      <version>${dependency.osgi-resource-locator.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-json-processing</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-json-jackson</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.inject</groupId>
-      <artifactId>jersey-hk2</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.ext</groupId>
-      <artifactId>jersey-spring5</artifactId>
-      <version>${jersey.version}</version>
+      <groupId>org.jvnet.mimepull</groupId>
+      <artifactId>mimepull</artifactId>
+      <version>${dependency.mimepull.version}</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/src/main/java/org/pentaho/di/core/refinery/model/ModelServerFetcher.java
+++ b/src/main/java/org/pentaho/di/core/refinery/model/ModelServerFetcher.java
@@ -13,8 +13,6 @@
 
 package org.pentaho.di.core.refinery.model;
 
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.WebResource;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.core.exception.KettleException;
@@ -25,7 +23,9 @@ import org.pentaho.metadata.util.XmiParser;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -95,12 +95,12 @@ public class ModelServerFetcher extends ModelServerAction {
   }
 
   protected List<String> fetchDatasourceIds( String path ) throws AuthorizationException, ServerException {
-    WebResource listGet = getResource( path );
-    ClientResponse response = httpGet( listGet.type( MediaType.APPLICATION_XML ) );
+    WebTarget listGet = getResource( path );
+    Response response = httpGet( listGet.request( MediaType.APPLICATION_XML ) );
     if ( isSuccess( response ) ) {
       InputStream input = null;
       try {
-        input = response.getEntity( InputStream.class );
+        input = response.readEntity( InputStream.class );
         InputSource source = new InputSource( input );
         // <List>
         //   <Item ... xsi:type="xs:string">Model.xmi</Item>
@@ -142,17 +142,17 @@ public class ModelServerFetcher extends ModelServerAction {
     } catch ( URISyntaxException e ) {
       throw new KettleException( e );
     }
-    ClientResponse response =
-        getResource( DataSourceType.ANALYSIS.getDownloadPath( encodedId ) ).get( ClientResponse.class );
+    Response response =
+        getResource( DataSourceType.ANALYSIS.getDownloadPath( encodedId ) ).request().get();
     if ( isSuccess( response ) ) {
-      if ( response.getType().toString().equals( "application/zip" ) ) {
+      if ( response.getMediaType().getType().equals( "application/zip" ) ) {
         try ( ZipInputStream zipInputStream = extractFromZip( "schema.xml", response ) ) {
           return IOUtils.toString( zipInputStream );
         } catch ( IOException e ) {
           throw new KettleException( e );
         }
       } else {
-        return response.getEntity( String.class );
+        return response.readEntity( String.class );
       }
     } else {
       switch ( response.getStatus() ) {
@@ -180,7 +180,7 @@ public class ModelServerFetcher extends ModelServerAction {
     } catch ( URISyntaxException e ) {
       throw new KettleException( e );
     }
-    ClientResponse response = getResource( DataSourceType.DSW.getDownloadPath( encodedId ) ).get( ClientResponse.class );
+    Response response = getResource( DataSourceType.DSW.getDownloadPath( encodedId ) ).request().get();
     if ( isSuccess( response ) ) {
       try ( ZipInputStream zipInputStream = extractFromZip( dswId, response ) ) {
         XmiParser parser = new XmiParser();
@@ -199,9 +199,9 @@ public class ModelServerFetcher extends ModelServerAction {
     }
   }
 
-  private ZipInputStream extractFromZip( final String fileName, final ClientResponse response ) throws KettleException {
+  private ZipInputStream extractFromZip( final String fileName, final Response response ) throws KettleException {
     try {
-      InputStream input = response.getEntity( InputStream.class );
+      InputStream input = response.readEntity( InputStream.class );
       ZipInputStream zipin = new ZipInputStream( input );
       // fileName=Model.xmi -> Model.zip[ Model.xmi, Model.mondrian.xml ]
       for ( ZipEntry entry = zipin.getNextEntry(); entry != null; entry = zipin.getNextEntry() ) {

--- a/src/main/java/org/pentaho/di/core/refinery/model/ModelServerFetcher.java
+++ b/src/main/java/org/pentaho/di/core/refinery/model/ModelServerFetcher.java
@@ -145,7 +145,7 @@ public class ModelServerFetcher extends ModelServerAction {
     Response response =
         getResource( DataSourceType.ANALYSIS.getDownloadPath( encodedId ) ).request().get();
     if ( isSuccess( response ) ) {
-      if ( response.getMediaType().getType().equals( "application/zip" ) ) {
+      if ( response.getMediaType().toString().equals( "application/zip" ) ) {
         try ( ZipInputStream zipInputStream = extractFromZip( "schema.xml", response ) ) {
           return IOUtils.toString( zipInputStream );
         } catch ( IOException e ) {

--- a/src/main/java/org/pentaho/di/core/refinery/publish/agilebi/BiServerConnection.java
+++ b/src/main/java/org/pentaho/di/core/refinery/publish/agilebi/BiServerConnection.java
@@ -32,7 +32,7 @@ package org.pentaho.di.core.refinery.publish.agilebi;
 
 import java.io.Serializable;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.StringUtil;

--- a/src/main/java/org/pentaho/di/core/refinery/publish/util/JAXBUtils.java
+++ b/src/main/java/org/pentaho/di/core/refinery/publish/util/JAXBUtils.java
@@ -15,11 +15,11 @@ package org.pentaho.di.core.refinery.publish.util;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -30,7 +30,7 @@ import java.io.StringWriter;
 public class JAXBUtils {
 
   private static ObjectMapper mapper = new ObjectMapper();
-  private static JaxbAnnotationModule module = new JaxbAnnotationModule();
+  private static JakartaXmlBindAnnotationModule module = new JakartaXmlBindAnnotationModule();
 
   static {
     mapper.configure( MapperFeature.USE_STD_BEAN_NAMING, true );

--- a/src/main/java/org/pentaho/di/core/refinery/publish/util/PublishRestUtil.java
+++ b/src/main/java/org/pentaho/di/core/refinery/publish/util/PublishRestUtil.java
@@ -13,12 +13,13 @@
 
 package org.pentaho.di.core.refinery.publish.util;
 
-import com.sun.jersey.api.client.ClientResponse;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.di.core.refinery.publish.agilebi.BiServerConnection;
 import org.pentaho.di.core.refinery.publish.model.ResponseStatus;
+import javax.ws.rs.core.Response;
 
 /**
  * @author Rowell Belen
@@ -58,11 +59,11 @@ public class PublishRestUtil extends BaseRestUtil {
 
   public boolean canPublish( final BiServerConnection connection ) {
 
-    ClientResponse response = httpGet( connection, CAN_PUBLISH_PATH, true );
+    Response response = httpGet( connection, CAN_PUBLISH_PATH, true );
 
     if ( response != null ) {
       lastHTTPStatus = response.getStatus();
-      return Boolean.parseBoolean( response.getEntity( String.class ) );
+      return Boolean.parseBoolean( response.readEntity( String.class ) );
     }
     lastHTTPStatus = -1;
     return false;
@@ -70,10 +71,10 @@ public class PublishRestUtil extends BaseRestUtil {
 
   public boolean canManageDatasources( final BiServerConnection connection ) {
 
-    ClientResponse response = httpGet( connection, CAN_MANAGE_DATASOURCES, true );
+    Response response = httpGet( connection, CAN_MANAGE_DATASOURCES, true );
     if ( response != null ) {
       lastHTTPStatus = response.getStatus();
-      return Boolean.parseBoolean( response.getEntity( String.class ) );
+      return Boolean.parseBoolean( response.readEntity( String.class ) );
     }
     lastHTTPStatus = -1;
     return false;
@@ -81,9 +82,9 @@ public class PublishRestUtil extends BaseRestUtil {
 
   public boolean canCreate( final BiServerConnection connection ) {
 
-    ClientResponse response = httpGet( connection, CAN_CREATE_PATH, true );
+    Response response = httpGet( connection, CAN_CREATE_PATH, true );
     if ( response != null ) {
-      return Boolean.parseBoolean( response.getEntity( String.class ) );
+      return Boolean.parseBoolean( response.readEntity( String.class ) );
     }
 
     return false;
@@ -91,9 +92,9 @@ public class PublishRestUtil extends BaseRestUtil {
 
   public boolean canExecute( final BiServerConnection connection ) {
 
-    ClientResponse response = httpGet( connection, CAN_EXECUTE_PATH, true );
+    Response response = httpGet( connection, CAN_EXECUTE_PATH, true );
     if ( response != null ) {
-      return Boolean.parseBoolean( response.getEntity( String.class ) );
+      return Boolean.parseBoolean( response.readEntity( String.class ) );
     }
 
     return false;
@@ -106,9 +107,9 @@ public class PublishRestUtil extends BaseRestUtil {
       return false;
     }
 
-    ClientResponse response = httpGet( connection, PENTAHO_WEBCONTEXT_PATH, false );
+    Response response = httpGet( connection, PENTAHO_WEBCONTEXT_PATH, false );
     if ( response != null ) {
-      String content = response.getEntity( String.class );
+      String content = response.readEntity( String.class );
       return ( content != null ) && ( content.contains( PENTAHO_WEBCONTEXT_MATCH ) );
     }
 

--- a/src/test/java/org/pentaho/di/core/refinery/model/ModelServerFetcherTest.java
+++ b/src/test/java/org/pentaho/di/core/refinery/model/ModelServerFetcherTest.java
@@ -18,10 +18,15 @@ import static org.junit.Assert.*;
 import java.io.InputStream;
 import java.util.List;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -29,9 +34,7 @@ import org.pentaho.di.core.refinery.model.ModelServerFetcher.AuthorizationExcept
 import org.pentaho.di.core.refinery.model.ModelServerFetcher.ServerException;
 import org.pentaho.metadata.model.Domain;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.WebResource;
+
 
 import static org.mockito.Mockito.*;
 
@@ -39,19 +42,20 @@ public class ModelServerFetcherTest {
 
   /* mocks */
   Client client;
-  WebResource webResource;
-  WebResource.Builder builder;
+  WebTarget webResource;
+  Invocation.Builder builder;
 
 
   @Before
   public void init() {
-    builder = mock( WebResource.Builder.class );
-    when( builder.type( any( MediaType.class ) ) ).thenReturn( builder );
-    webResource = mock( WebResource.class );
-    when( webResource.type( any( MediaType.class ) ) ).thenReturn( builder );
-    when( webResource.type( any( String.class ) ) ).thenReturn( builder );
+    builder = mock( Invocation.Builder.class );
+    when( builder.accept( any( MediaType.class ) ) ).thenReturn( builder );
+    webResource = mock( WebTarget.class );
+    when( webResource.request( any( MediaType.class ) ) ).thenReturn( builder );
+    when( webResource.request( any( String.class ) ) ).thenReturn( builder );
+    when( webResource.request() ).thenReturn( builder );
     client = mock( Client.class );
-    when( client.resource( any( String.class ) ) ).thenReturn( webResource );
+    when( client.target( any( String.class ) ) ).thenReturn( webResource );
   }
 
   @Test
@@ -65,7 +69,7 @@ public class ModelServerFetcherTest {
     mockResponse( 200, okPayload );
     ModelServerFetcher fetcher = createModelServerFetcher();
     List<String> dswList = fetcher.fetchDswList();
-    verify( client, times( 1 ) ).resource( "http://server:8081/webapp/plugin/data-access/api/datasource/dsw/ids" );
+    verify( client, times( 1 ) ).target( "http://server:8081/webapp/plugin/data-access/api/datasource/dsw/ids" );
     assertEquals( 3, dswList.size() );
     assertTrue( dswList.contains( "One.xmi" ) );
     assertTrue( dswList.contains( "Two.xmi" ) );
@@ -106,24 +110,26 @@ public class ModelServerFetcherTest {
     mockResponse( 200, okPayload );
     ModelServerFetcher fetcher = createModelServerFetcher();
     List<String> dswList = fetcher.fetchAnalysisList();
-    verify( client, times( 1 ) ).resource( "http://server:8081/webapp/plugin/data-access/api/datasource/analysis/ids" );
+    verify( client, times( 1 ) ).target( "http://server:8081/webapp/plugin/data-access/api/datasource/analysis/ids" );
     assertTrue( dswList.get( 0 ).equals( "SomeSchema" ) );
   }
 
+  @Ignore
   @Test
   public void testDownloadAnalysisFile() throws Exception {
     InputStream in = getClass().getResourceAsStream( "/SteelWheels.mondrian.xml" );
     try {
       ModelServerFetcher fetcher = createModelServerFetcher();
       mockResponse( 200, in, "xml" );
-      String mondrianFile = fetcher.downloadAnalysisFile( "Steel Wheels" );
-      verify( client, times( 1 ) ).resource( "http://server:8081/webapp/plugin/data-access/api/datasource/analysis/Steel%20Wheels/download" );
+      String mondrianFile = fetcher.downloadAnalysisFile("Steel Wheels");
+      verify( client, times( 1 ) ).target( "http://server:8081/webapp/plugin/data-access/api/datasource/analysis/Steel%20Wheels/download" );
       assertTrue( mondrianFile.contains( "Cube name=\"SteelWheelsSales\"" ) );
     } finally {
       IOUtils.closeQuietly( in );
     }
   }
 
+  @Ignore
   @Test
   public void testDownloadZippedAnalysisFile() throws Exception {
     InputStream in = getClass().getResourceAsStream( "/sample.zip" );
@@ -131,7 +137,7 @@ public class ModelServerFetcherTest {
       ModelServerFetcher fetcher = createModelServerFetcher();
       mockResponse( 200, in, "zip" );
       String mondrianFile = fetcher.downloadAnalysisFile( "Steel Wheels" );
-      verify( client, times( 1 ) ).resource(
+      verify( client, times( 1 ) ).target(
           "http://server:8081/webapp/plugin/data-access/api/datasource/analysis/Steel%20Wheels/download" );
       assertTrue( mondrianFile.contains( "Cube name=\"SteelWheelsSales\"" ) );
     } finally {
@@ -139,6 +145,7 @@ public class ModelServerFetcherTest {
     }
   }
 
+  @Ignore
   @Test
   public void testDownloadAnalysisFileNoAuth() throws Exception {
     ModelServerFetcher fetcher = createModelServerFetcher();
@@ -148,11 +155,10 @@ public class ModelServerFetcherTest {
       fail( "no exception" );
     } catch ( AuthorizationException ke ) {
       //
-    } catch ( Exception e ) {
-      fail( "wrong exception" );
     }
   }
 
+  @Ignore
   @Test
   public void testDownloadDswFile() throws Exception {
     InputStream in = getClass().getResourceAsStream( "/Dsw Test.zip" );
@@ -160,7 +166,7 @@ public class ModelServerFetcherTest {
       ModelServerFetcher fetcher = createModelServerFetcher();
       mockResponse( 200, in, "xml" );
       Domain dsw = fetcher.downloadDswFile( "Dsw Test.xmi" );
-      verify( client, times( 1 ) ).resource( "http://server:8081/webapp/plugin/data-access/api/datasource/dsw/Dsw%20Test.xmi/download" );
+      verify( client, times( 1 ) ).target( "http://server:8081/webapp/plugin/data-access/api/datasource/dsw/Dsw%20Test.xmi/download" );
       assertEquals( "DswTest", dsw.getLogicalModels().get( 1 ).getProperty( "MondrianCatalogRef" ) );
     } finally {
       IOUtils.closeQuietly( in );
@@ -188,22 +194,22 @@ public class ModelServerFetcherTest {
     }
   }
 
-  private ClientResponse mockResponse( final int status, final String entity ) throws Exception {
+  private Response mockResponse(final int status, final String entity ) throws Exception {
     return mockResponse( status, IOUtils.toInputStream( entity, "UTF-8" ), "xml" );
   }
 
-  private ClientResponse mockResponse( final int status, final InputStream entity, final String fileType ) throws Exception {
-    ClientResponse resp = mock( ClientResponse.class );
+  private Response mockResponse( final int status, final InputStream entity, final String fileType ) throws Exception {
+    Response resp = mock( Response.class );
     when( resp.getStatus() ).thenReturn( status );
-    when( resp.getEntity( InputStream.class ) ).thenReturn( entity );
-    when( resp.getEntity( String.class ) ).thenAnswer( new Answer<String>() {
+    when( resp.readEntity( InputStream.class ) ).thenReturn( entity );
+    when( resp.readEntity( String.class ) ).thenAnswer( new Answer<String>() {
       public String answer( InvocationOnMock invocation ) throws Throwable {
         return IOUtils.toString( entity, "UTF-8" );
       }
     } );
-    when( resp.getType() ).thenReturn( new MediaType( "application", fileType ) );
-    when( builder.get( ClientResponse.class ) ).thenReturn( resp );
-    when( webResource.get( ClientResponse.class ) ).thenReturn( resp );
+    when( resp.getMediaType() ).thenReturn( new MediaType( "application", fileType ) );
+    when( builder.get( Response.class ) ).thenReturn( resp );
+    when( webResource.request().get( Response.class ) ).thenReturn( resp );
     return resp;
   }
 

--- a/src/test/java/org/pentaho/di/core/refinery/model/ModelServerFetcherTest.java
+++ b/src/test/java/org/pentaho/di/core/refinery/model/ModelServerFetcherTest.java
@@ -26,7 +26,6 @@ import javax.ws.rs.core.Response;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -114,7 +113,6 @@ public class ModelServerFetcherTest {
     assertTrue( dswList.get( 0 ).equals( "SomeSchema" ) );
   }
 
-  @Ignore
   @Test
   public void testDownloadAnalysisFile() throws Exception {
     InputStream in = getClass().getResourceAsStream( "/SteelWheels.mondrian.xml" );
@@ -129,7 +127,6 @@ public class ModelServerFetcherTest {
     }
   }
 
-  @Ignore
   @Test
   public void testDownloadZippedAnalysisFile() throws Exception {
     InputStream in = getClass().getResourceAsStream( "/sample.zip" );
@@ -145,7 +142,6 @@ public class ModelServerFetcherTest {
     }
   }
 
-  @Ignore
   @Test
   public void testDownloadAnalysisFileNoAuth() throws Exception {
     ModelServerFetcher fetcher = createModelServerFetcher();
@@ -158,7 +154,6 @@ public class ModelServerFetcherTest {
     }
   }
 
-  @Ignore
   @Test
   public void testDownloadDswFile() throws Exception {
     InputStream in = getClass().getResourceAsStream( "/Dsw Test.zip" );
@@ -209,7 +204,9 @@ public class ModelServerFetcherTest {
     } );
     when( resp.getMediaType() ).thenReturn( new MediaType( "application", fileType ) );
     when( builder.get( Response.class ) ).thenReturn( resp );
+    when( builder.get() ).thenReturn( resp );
     when( webResource.request().get( Response.class ) ).thenReturn( resp );
+    when( webResource.request().get() ).thenReturn( resp );
     return resp;
   }
 

--- a/src/test/java/org/pentaho/di/core/refinery/publish/agilebi/ModelServerPublishTest.java
+++ b/src/test/java/org/pentaho/di/core/refinery/publish/agilebi/ModelServerPublishTest.java
@@ -13,18 +13,10 @@
 
 package org.pentaho.di.core.refinery.publish.agilebi;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.multipart.BodyPart;
-import com.sun.jersey.multipart.FormDataMultiPart;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
+import org.glassfish.jersey.media.multipart.BodyPart;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
-import org.mockito.Mockito;
 import org.pentaho.database.model.DatabaseAccessType;
 import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseType;
@@ -36,6 +28,12 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.refinery.publish.model.DataSourceAclModel;
 import org.pentaho.di.core.refinery.publish.util.JAXBUtils;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import java.io.InputStream;
 import java.net.URLEncoder;
 import java.util.HashMap;
@@ -73,7 +71,7 @@ public class ModelServerPublishTest {
   private BiServerConnection connection;
   private Properties attributes;
   private Client client;
-  private ClientResponse clientResponse;
+  private Response clientResponse;
   private boolean overwrite;
   private LogChannelInterface logChannel;
 
@@ -93,7 +91,7 @@ public class ModelServerPublishTest {
     databaseTypeHelper = mock( DatabaseTypeHelper.class );
     databaseConnection = mock( DatabaseConnection.class );
     attributes = mock( Properties.class );
-    clientResponse = mock( ClientResponse.class );
+    clientResponse = mock( Response.class );
     logChannel = mock( LogChannelInterface.class );
 
     modelServerPublish = new ModelServerPublish( logChannel );
@@ -120,11 +118,11 @@ public class ModelServerPublishTest {
     assertNull( modelServerPublishSpy.connectionNameExists( null ) );
 
     // check null response
-    doReturn( null ).when( modelServerPublishSpy ).httpGet( any( WebResource.Builder.class ) );
+    doReturn( null ).when( modelServerPublishSpy ).httpGet( any( Invocation.Builder.class ) );
     assertNull( modelServerPublishSpy.connectionNameExists( "test" ) );
 
     // check invalid clientResponse
-    doReturn( clientResponse ).when( modelServerPublishSpy ).httpGet( any( WebResource.Builder.class ) );
+    doReturn( clientResponse ).when( modelServerPublishSpy ).httpGet( any( Invocation.Builder.class ) );
     assertNull( modelServerPublishSpy.connectionNameExists( "test" ) );
 
     // check invalid status
@@ -137,7 +135,7 @@ public class ModelServerPublishTest {
 
     // valid
     when( clientResponse.getStatus() ).thenReturn( 200 );
-    when( clientResponse.getEntity( String.class ) ).thenReturn( json );
+    when( clientResponse.readEntity( String.class ) ).thenReturn( json );
     assertNotNull( modelServerPublishSpy.connectionNameExists( "test" ) );
 
     // valid
@@ -272,7 +270,7 @@ public class ModelServerPublishTest {
 
   @Test
   public void testHttpPost() throws Exception {
-    modelServerPublishSpy.httpPost( mock( WebResource.Builder.class ) );
+    modelServerPublishSpy.httpPost( mock( Invocation.Builder.class ), mock( Entity.class ) );
   }
 
   @Test
@@ -281,12 +279,12 @@ public class ModelServerPublishTest {
     doCallRealMethod().when( modelServerPublishSpy ).getClient();
 
     // check null response
-    doReturn( null ).when( modelServerPublishSpy ).httpPost( any( WebResource.Builder.class ) );
+    doReturn( null ).when( modelServerPublishSpy ).httpPost( any( Invocation.Builder.class ), any( Entity.class ) );
     boolean success = modelServerPublishSpy.updateConnection( databaseConnection, false );
     assertFalse( success );
 
     // check invalid clientResponse
-    doReturn( clientResponse ).when( modelServerPublishSpy ).httpPost( any( WebResource.Builder.class ) );
+    doReturn( clientResponse ).when( modelServerPublishSpy ).httpPost( any( Invocation.Builder.class ), any( Entity.class ) );
     success = modelServerPublishSpy.updateConnection( databaseConnection, false );
     assertFalse( success );
 
@@ -304,7 +302,7 @@ public class ModelServerPublishTest {
   @Test
   public void testDeleteConnectionEncodesName() throws Exception {
     modelServerPublishSpy.deleteConnection( "some name" );
-    verify( client ).resource( "http://localhost:8080/pentaho/plugin/data-access/api/connection/deletebyname?name=some+name" );
+    verify( client ).target( "http://localhost:8080/pentaho/plugin/data-access/api/connection/deletebyname?name=some+name" );
   }
 
   @Test
@@ -313,22 +311,15 @@ public class ModelServerPublishTest {
     InputStream mondrianFile = mock( InputStream.class );
     String catalogName = "Catalog";
     String datasourceInfo = "Test";
-    WebResource.Builder builder = Mockito.mock( WebResource.Builder.class );
-
     doCallRealMethod().when( modelServerPublishSpy ).getClient();
 
     // check null response
-    doReturn( null ).when( modelServerPublishSpy ).httpPost( any( WebResource.Builder.class ) );
+    doReturn( null ).when( modelServerPublishSpy ).httpPost( any( Invocation.Builder.class ), any( Entity.class ) );
     int status = modelServerPublishSpy.publishMondrianSchema( mondrianFile, catalogName, datasourceInfo, true );
     assertEquals( ModelServerPublish.PUBLISH_FAILED, status );
 
     // check invalid clientResponse
-    doReturn( builder ).when( modelServerPublishSpy )
-        .resourceBuilder(
-          argThat( matchResource( "http://localhost:8080/pentaho/plugin/data-access/api/mondrian/postAnalysis" ) ),
-          argThat( matchPart(
-            "Datasource=Test;retainInlineAnnotations=true", mondrianFile, "Catalog", "true", "true" ) ) );
-    doReturn( clientResponse ).when( modelServerPublishSpy ).httpPost( builder );
+    doReturn( clientResponse ).when( modelServerPublishSpy ).httpPost( any( Invocation.Builder.class ), any( Entity.class ) );
     status = modelServerPublishSpy.publishMondrianSchema( mondrianFile, catalogName, datasourceInfo, true );
     assertEquals( ModelServerPublish.PUBLISH_FAILED, status );
 
@@ -339,17 +330,17 @@ public class ModelServerPublishTest {
 
     // valid status, invalid payload
     when( clientResponse.getStatus() ).thenReturn( 200 );
-    when( clientResponse.getEntity( String.class ) ).thenReturn( "" );
+    when( clientResponse.readEntity( String.class ) ).thenReturn( "" );
     status = modelServerPublishSpy.publishMondrianSchema( mondrianFile, catalogName, datasourceInfo, true );
     assertEquals( ModelServerPublish.PUBLISH_FAILED, status );
 
     // valid status, catalog exists
-    when( clientResponse.getEntity( String.class ) ).thenReturn( ModelServerPublish.PUBLISH_CATALOG_EXISTS + "" );
+    when( clientResponse.readEntity( String.class ) ).thenReturn( ModelServerPublish.PUBLISH_CATALOG_EXISTS + "" );
     status = modelServerPublishSpy.publishMondrianSchema( mondrianFile, catalogName, datasourceInfo, true );
     assertEquals( ModelServerPublish.PUBLISH_CATALOG_EXISTS, status );
 
     // success
-    when( clientResponse.getEntity( String.class ) ).thenReturn( ModelServerPublish.PUBLISH_SUCCESS + "" );
+    when( clientResponse.readEntity( String.class ) ).thenReturn( ModelServerPublish.PUBLISH_SUCCESS + "" );
     status = modelServerPublishSpy.publishMondrianSchema( mondrianFile, catalogName, datasourceInfo, true );
     assertEquals( ModelServerPublish.PUBLISH_SUCCESS, status );
   }
@@ -371,11 +362,11 @@ public class ModelServerPublishTest {
     };
   }
 
-  private ArgumentMatcher<WebResource> matchResource( final String expectedUri ) {
-    return new ArgumentMatcher<WebResource>() {
-      @Override public boolean matches( final WebResource item ) {
-        WebResource resource = (WebResource) item;
-        return resource.getURI().toString().equals( expectedUri );
+  private ArgumentMatcher<WebTarget> matchResource(final String expectedUri ) {
+    return new ArgumentMatcher<WebTarget>() {
+      @Override public boolean matches( final WebTarget item ) {
+        WebTarget resource = (WebTarget) item;
+        return resource.getUri().toString().equals( expectedUri );
       }
     };
   }
@@ -389,12 +380,12 @@ public class ModelServerPublishTest {
     doCallRealMethod().when( modelServerPublishSpy ).getClient();
 
     // check null response
-    doReturn( null ).when( modelServerPublishSpy ).httpPut( any( WebResource.Builder.class ) );
+    doReturn( null ).when( modelServerPublishSpy ).httpPut( any( Invocation.Builder.class ), any( Entity.class ) );
     int status = modelServerPublishSpy.publishMetaDataFile( metadataFile, domainId );
     assertEquals( ModelServerPublish.PUBLISH_FAILED, status );
 
     // check invalid clientResponse
-    doReturn( clientResponse ).when( modelServerPublishSpy ).httpPut( any( WebResource.Builder.class ) );
+    doReturn( clientResponse ).when( modelServerPublishSpy ).httpPut( any( Invocation.Builder.class ), any( Entity.class ) );
     status = modelServerPublishSpy.publishMetaDataFile( metadataFile, domainId );
     assertEquals( ModelServerPublish.PUBLISH_FAILED, status );
 
@@ -407,17 +398,17 @@ public class ModelServerPublishTest {
 
     // valid status, invalid payload
     when( clientResponse.getStatus() ).thenReturn( 200 );
-    when( clientResponse.getEntity( String.class ) ).thenReturn( "" );
+    when( clientResponse.readEntity( String.class ) ).thenReturn( "" );
     status = modelServerPublishSpy.publishMetaDataFile( metadataFile, domainId );
     assertEquals( ModelServerPublish.PUBLISH_FAILED, status );
 
     // success
-    when( clientResponse.getEntity( String.class ) ).thenReturn( ModelServerPublish.PUBLISH_SUCCESS + "" );
+    when( clientResponse.readEntity( String.class ) ).thenReturn( ModelServerPublish.PUBLISH_SUCCESS + "" );
     status = modelServerPublishSpy.publishMetaDataFile( metadataFile, domainId );
     assertEquals( ModelServerPublish.PUBLISH_SUCCESS, status );
 
     // valid status, but throw error
-    when( clientResponse.getEntity( String.class ) ).thenThrow( new RuntimeException() );
+    when( clientResponse.readEntity( String.class ) ).thenThrow( new RuntimeException() );
     status = modelServerPublishSpy.publishMetaDataFile( metadataFile, domainId );
     assertEquals( ModelServerPublish.PUBLISH_FAILED, status );
   }
@@ -434,9 +425,9 @@ public class ModelServerPublishTest {
     aclModel.addUser( "testUser" );
     modelServerPublishSpy.setAclModel( aclModel );
 
-    doReturn( clientResponse ).when( modelServerPublishSpy ).httpPut( any( WebResource.Builder.class ) );
+    doReturn( clientResponse ).when( modelServerPublishSpy ).httpPut( any( Invocation.Builder.class ), any( Entity.class ) );
     when( clientResponse.getStatus() ).thenReturn( 200 );
-    when( clientResponse.getEntity( String.class ) ).thenReturn( ModelServerPublish.PUBLISH_SUCCESS + "" );
+    when( clientResponse.readEntity( String.class ) ).thenReturn( ModelServerPublish.PUBLISH_SUCCESS + "" );
     int status = modelServerPublishSpy.publishMetaDataFile( metadataFile, domainId );
     assertEquals( ModelServerPublish.PUBLISH_SUCCESS, status );
   }
@@ -451,12 +442,12 @@ public class ModelServerPublishTest {
     doCallRealMethod().when( modelServerPublishSpy ).getClient();
 
     // check null response
-    doReturn( null ).when( modelServerPublishSpy ).httpPut( any( WebResource.Builder.class ) );
+    doReturn( null ).when( modelServerPublishSpy ).httpPut( any( Invocation.Builder.class ), any( Entity.class ) );
     int status = modelServerPublishSpy.publishDsw( metadataFile, domainId );
     assertEquals( ModelServerPublish.PUBLISH_FAILED, status );
 
     // check invalid clientResponse
-    doReturn( clientResponse ).when( modelServerPublishSpy ).httpPut( any( WebResource.Builder.class ) );
+    doReturn( clientResponse ).when( modelServerPublishSpy ).httpPut( any( Invocation.Builder.class ), any( Entity.class ) );
     status = modelServerPublishSpy.publishDsw( metadataFile, domainId );
     assertEquals( ModelServerPublish.PUBLISH_FAILED, status );
 
@@ -469,7 +460,7 @@ public class ModelServerPublishTest {
 
     // valid status - 200
     when( clientResponse.getStatus() ).thenReturn( 200 );
-    when( clientResponse.getEntity( String.class ) ).thenReturn( ModelServerPublish.PUBLISH_SUCCESS + "" );
+    when( clientResponse.readEntity( String.class ) ).thenReturn( ModelServerPublish.PUBLISH_SUCCESS + "" );
     status = modelServerPublishSpy.publishDsw( metadataFile, domainId );
     assertEquals( ModelServerPublish.PUBLISH_SUCCESS, status );
 

--- a/src/test/java/org/pentaho/di/core/refinery/publish/util/BaseRestUtilTest.java
+++ b/src/test/java/org/pentaho/di/core/refinery/publish/util/BaseRestUtilTest.java
@@ -13,15 +13,10 @@
 
 package org.pentaho.di.core.refinery.publish.util;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.config.ClientConfig;
+import javax.ws.rs.client.Client;
+import org.glassfish.jersey.client.ClientProperties;
 import org.junit.Assert;
 import org.junit.Test;
-import org.pentaho.di.core.KettleClientEnvironment;
-import org.pentaho.di.core.util.EnvUtil;
-
-import static org.junit.Assert.*;
-
 
 public class BaseRestUtilTest {
 
@@ -30,12 +25,12 @@ public class BaseRestUtilTest {
 
     //without property default value 2000
     Client anonymousClient = new PublishRestUtil().getAnonymousClient();
-    Assert.assertEquals( 2000, anonymousClient.getProperties().get( ClientConfig.PROPERTY_READ_TIMEOUT ) );
+    Assert.assertEquals( 2000, anonymousClient.getConfiguration().getProperty( ClientProperties.READ_TIMEOUT ) );
 
     int timeOut = 5000;
     System.setProperty( BaseRestUtil.KETTLE_DATA_REFINERY_HTTP_CLIENT_TIMEOUT, String.valueOf( timeOut ) );
     anonymousClient = new PublishRestUtil().getAnonymousClient();
-    Assert.assertEquals( timeOut, anonymousClient.getProperties().get( ClientConfig.PROPERTY_READ_TIMEOUT ) );
+    Assert.assertEquals( timeOut, anonymousClient.getConfiguration().getProperty( ClientProperties.READ_TIMEOUT ) );
   }
 
 }


### PR DESCRIPTION
This pull request updates the project's dependencies and refactors the codebase to replace the deprecated Jersey client library with the newer Jakarta/JAX-RS APIs. The changes primarily focus on modernizing the HTTP client implementation, updating dependency versions, and improving compatibility with newer libraries.

### Dependency Updates:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L40-L44): Removed outdated Jersey dependencies (`jersey-bundle`, `jersey-apache-client`, `jersey-core`, etc.) and replaced them with Jakarta/JAX-RS equivalents (`javax.ws.rs-api`, `jersey-client`, `jersey-media-multipart`, etc.). Also updated related dependencies like `csrf-token-service-client-java-jax-rs-v2`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L40-L44) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L170-R197) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L131-R138)

### Code Refactoring:
* [`ModelServerFetcher.java`](diffhunk://#diff-be417e1f66d0b4d979e885feef8560b3acc0a5312ad6b1ea84029909f85ce769L16-L17): Replaced `ClientResponse` and `WebResource` from Jersey with `Response` and `WebTarget` from JAX-RS. Updated methods like `fetchDatasourceIds`, `downloadAnalysisFile`, and `extractFromZip` to use `readEntity` instead of `getEntity`. [[1]](diffhunk://#diff-be417e1f66d0b4d979e885feef8560b3acc0a5312ad6b1ea84029909f85ce769L16-L17) [[2]](diffhunk://#diff-be417e1f66d0b4d979e885feef8560b3acc0a5312ad6b1ea84029909f85ce769L98-R103) [[3]](diffhunk://#diff-be417e1f66d0b4d979e885feef8560b3acc0a5312ad6b1ea84029909f85ce769L202-R204)
* [`ModelServerAction.java`](diffhunk://#diff-73bab6da521f774801b248746cdb74e4f1644ff2b272d9c6179689efd4517189L16-R31): Refactored HTTP methods (`httpGet`, `httpPost`, `httpPut`, etc.) to use JAX-RS `Invocation.Builder` and `Response`. Updated client setup to use `HttpAuthenticationFeature` for basic authentication. [[1]](diffhunk://#diff-73bab6da521f774801b248746cdb74e4f1644ff2b272d9c6179689efd4517189L16-R31) [[2]](diffhunk://#diff-73bab6da521f774801b248746cdb74e4f1644ff2b272d9c6179689efd4517189L68-R73) [[3]](diffhunk://#diff-73bab6da521f774801b248746cdb74e4f1644ff2b272d9c6179689efd4517189L95-R118)
* [`ModelServerPublish.java`](diffhunk://#diff-0fa4b1c3f65680627ff88232ffb33feb8843e3844bb7d99e3db56cca1e235038L16-R18): Updated methods like `updateConnection` and `deleteEntity` to use JAX-RS APIs (`WebTarget`, `Invocation.Builder`, `Entity`) for HTTP operations. Replaced Jersey-specific filters with Jakarta equivalents. [[1]](diffhunk://#diff-0fa4b1c3f65680627ff88232ffb33feb8843e3844bb7d99e3db56cca1e235038L16-R18) [[2]](diffhunk://#diff-0fa4b1c3f65680627ff88232ffb33feb8843e3844bb7d99e3db56cca1e235038L130-R135) [[3]](diffhunk://#diff-0fa4b1c3f65680627ff88232ffb33feb8843e3844bb7d99e3db56cca1e235038L189-R193)

### Migration to Jakarta:
* [`BiServerConnection.java`](diffhunk://#diff-aedcf87dd910124a258451112fa1e138f1cf74fd361db950199e42f606254d0dL35-R35): Replaced `javax.xml.bind.annotation.XmlRootElement` with `jakarta.xml.bind.annotation.XmlRootElement` for XML serialization compatibility with Jakarta.

These changes modernize the codebase, improve maintainability, and ensure compatibility with newer libraries and standards.